### PR TITLE
autoOrient belongs to Layer, not AVLayer

### DIFF
--- a/docs/layers/avlayer.rst
+++ b/docs/layers/avlayer.rst
@@ -129,28 +129,6 @@ Boolean; read/write.
 
 ----
 
-.. _AVLayer.autoOrient:
-
-AVLayer.autoOrient
-*********************************************
-
-``app.project.item(index).layer(index).autoOrient``
-
-**Description**
-
-The type of automatic orientation to perform for the layer.
-
-**Type**
-
-An ``AutoOrientType`` enumerated value; read/write. One of:
-
--  ``AutoOrientType.ALONG_PATH`` Layer faces in the direction of the motion path.
--  ``AutoOrientType.CAMERA_OR_POINT_OF_INTEREST`` Layer always faces the active camera or points at its point of interest.
--  ``AutoOrientType.CHARACTERS_TOWARD_CAMERA`` Each character in a per-character 3D text layer automatically faces the active camera.
--  ``AutoOrientType.NO_AUTO_ORIENT`` Layer rotates freely, independent of any motion path, point of interest, or other layers.
-
-----
-
 .. _AVLayer.blendingMode:
 
 AVLayer.blendingMode

--- a/docs/layers/layer.rst
+++ b/docs/layers/layer.rst
@@ -30,6 +30,28 @@ If the first item in the project is a :ref:`CompItem <CompItem>`, this example d
 Attributes
 ==========
 
+.. _Layer.autoOrient:
+
+Layer.autoOrient
+*********************************************
+
+``app.project.item(index).layer(index).autoOrient``
+
+**Description**
+
+The type of automatic orientation to perform for the layer.
+
+**Type**
+
+An ``AutoOrientType`` enumerated value; read/write. One of:
+
+-  ``AutoOrientType.ALONG_PATH`` Layer faces in the direction of the motion path.
+-  ``AutoOrientType.CAMERA_OR_POINT_OF_INTEREST`` Layer always faces the active camera or points at its point of interest.
+-  ``AutoOrientType.CHARACTERS_TOWARD_CAMERA`` Each character in a per-character 3D text layer automatically faces the active camera.
+-  ``AutoOrientType.NO_AUTO_ORIENT`` Layer rotates freely, independent of any motion path, point of interest, or other layers.
+
+----
+
 .. _Layer.comment:
 
 Layer.comment


### PR DESCRIPTION
Also Camera, Light and even JSON layers have the autoOrient Attribut. Hence, it must belong to Layer, not AVLayer