### PR TITLE
layer.applyPreset acts on selected layers

### DIFF
--- a/docs/layers/layer.rst
+++ b/docs/layers/layer.rst
@@ -424,9 +424,12 @@ Layer.applyPreset()
 
 **Description**
 
-Applies the specified collection of animation settings (an animation preset) to the layer.
+Applies the specified collection of animation settings (an animation preset) to all the currently selected layers of the comp to which the layer belongs. If no layer is selected, it applies the animation preset to a new solid layer.
 
 Predefined animation preset files are installed in the Presets folder, and users can create new animation presets through the user interface.
+
+.. warning::
+   The animation preset is applied to the the selected layer(s) of the comp, not to the layer whose applyPreset function is called. Hence, the layer whose applyPreset function is called effectively just determines the comp whose layers are processed.
 
 **Parameters**
 


### PR DESCRIPTION
Here is the relevant email communication with @jthomascolombo about that topic:

------------------------------
From: Mathias Möhl 
 
Hi John,

I just noticed that Layer.applyPreset() always applies the preset to the selected layers and not to the layer from which the function is actually called.

steps to reproduce
(I tested with Ae 17.7.0 on Mac OS Big Sur):

1) create a comp with two (AV) layers.
2) select the first of these layers
3) run this code (adjust path to the ffx file to fit your Ae installation)
app.project.activeItem.layers[2].applyPreset(File('/Applications/Adobe After Effects 2020/Presets/Backgrounds/Blocks.ffx'));

It applies the preset to the first layer instead of the second one. 

Side notes:
- If you select multiple layers, it applies the preset to all of them (although applyPreset() is only called for one layer).
- if you have no layers selected, it applies to to a new layer
- if you call the function from a layer that is not included in the active comp, it first makes the comp of that layer active but then again, instead of using the layer itself, it uses the selected layers of that composition.

Do you know if this odd behavior is consistent among all Ae versions?

Cheers,
Mathias
------------------------------
From: John Colombo

Hi Mathias,

This rang a bell for me, so I searched and found that this appears to have been an issue for quite a while: https://creativecow.net/forums/thread/ae-script-applypreset/. That forum post is from 2009.

This appears to me to be by design so that the scripting call matches the behavior in the UI, but this was implemented long before I joined the team. However, I do agree with you that the expected behavior would be to apply the preset to the layer on which the method was called. I'm not sure if updating the behavior could be called a bug fix per se, but it would certainly be an improvement and a good feature request.
John, AE QE



