### PR TITLE
Revisions to Fonts, Font, and TextDocument.

### DIFF
--- a/docs/other/fontobject.rst
+++ b/docs/other/fontobject.rst
@@ -8,6 +8,8 @@ Font object
 
 The Font object provides information about a specific font, along with the font technology used, helping disambiguate when multiple fonts sharing the same Postscript name are installed on the system.
 
+Most of these APIs simply return information which is contained in the Font data file itself, seek more information there.
+
 .. note::
    | This functionality was added in After Effects 24.0.
    | This functionality is currently in Beta and is subject to change.
@@ -27,7 +29,7 @@ FontObject.familyName
 
 **Description**
 
-The family name of the font.
+The family name of the font, in the ASCII character set.
 
 **Type**
 
@@ -44,7 +46,8 @@ FontObject.fullName
 
 **Description**
 
-The full name of the font. Usually composed of the family name and the style name.
+The full name of the font, in the ASCII character set. Usually composed of the family name and the style name. 
+
 
 **Type**
 
@@ -78,7 +81,7 @@ FontObject.isSubstitute
 
 **Description**
 
-Returns true when the font is missing on project open.
+Returns true when this font instance represents a font reference which was missing on project open.
 
 **Type**
 
@@ -115,7 +118,7 @@ FontObject.nativeFamilyName
 
 **Description**
 
-The native family name of the font. The native name is the internal family name of the font and can be different from the usual family name.
+The native family name of the font in full 16 bit Unicode. Often different than what is returned from ``familyName`` for non-Latin fonts.
 
 **Type**
 
@@ -128,11 +131,11 @@ String; read-only.
 FontObject.nativeFullName
 *********************************************
 
-``app.fonts.allFonts[0][0].nativefullName``
+``app.fonts.allFonts[0][0].nativeFullName``
 
 **Description**
 
-The native full name of the font. It is usually composed of the native family name and native style name of the font.
+The native full name of the font in full 16 bit Unicode. Often different than what is returned from ``fullName`` for non-Latin fonts.
 
 **Type**
 
@@ -149,7 +152,7 @@ FontObject.nativeStyleName
 
 **Description**
 
-The native style name of the font. This is the internal name of the style and can be different from the usual style name.
+The native style name of the font in full 16 bit Unicode. Often different than what is returned from ``styleName`` for non-Latin fonts.
 
 **Type**
 
@@ -183,7 +186,7 @@ FontObject.styleName
 
 **Description**
 
-The style name of the font.
+The style name of the font, in the ASCII character set.
 
 **Type**
 

--- a/docs/other/fontsobject.rst
+++ b/docs/other/fontsobject.rst
@@ -29,11 +29,26 @@ FontsObject.allFonts
 
 **Description**
 
-The list of all the fonts currently available on your system, sorted by Font Family.
+The list of all the fonts currently available on your system.
+
+They are grouped into what is named a family group which are Arrays of :ref:`fontobject`.
+
+.. Naming and ordering::
+
+The Family Name of the group is simply the ``Font.familyName`` of any of the :ref:`fontobject` in the group.
+
+The Family Name in one font group is not guaranteed to have unique name compared to different font groups - the grouping is determined by a number of factors including the returned value of ``Font.technology`` and ``Font.writingScripts``.
+
+In addition, it is perfectly acceptable to have multiple fonts with the same PostScript name, though only one will have the same (PostScript name, Technology, Primary Writing Script) tuple. In the case of true duplicates, it is undefined which will be returned and which will be suppressed.
+
+The family groups and :ref:`fontobject` in the group are sorted accordingly to the setting in the ``Character Panel`` dropdown ``Show Font Names in English``. If set to true, the ``Font.familyName`` and ``Font.styleName`` property is used, otherwise the ``Font.nativeFamilyName`` and ``Font.nativeStyleName`` property is used.
+
+:ref:`fontobject` for which ``Font.isSubstitute`` returns true are always sorted to the end as individual family groups.
+
 
 **Type**
 
-Array of Arrays; read-only.
+Array of Arrays of :ref:`fontobject`; read-only.
 
 **Example**
 
@@ -41,12 +56,12 @@ This example will select the first returned Font Family Array.
 
 .. code:: javascript
 
-   // Getting the first available Font Family on the system
-   var firstFont = app.fonts.allFonts[0];
+   // Getting the first available Font Family Group on the system
+   var firstFontGroup = app.fonts.allFonts[0];
 
    // Getting the first Style for that Font Family
-   var firstFontFamilyName = firstFont[0].familyName;
-   var firstFamilyStyle = firstFont[0].styleName;
+   var firstFontFamilyName = firstFontGroup[0].familyName;
+   var firstFamilyStyle = firstFontGroup[0].styleName;
 
    alert(firstFontFamilyName+" "+firstFamilyStyle);
 
@@ -71,7 +86,7 @@ The list of all the missing or substituted fonts of the current Project.
 
 **Type**
 
-Array of fontObjects; read-only.
+Array of :ref:`fontobject`; read-only.
 
 ----
 
@@ -107,7 +122,7 @@ StyleName               A string containing the Style Name of the font.
 
 **Returns**
 
-An array of fontObjects.
+An array of :ref:`fontobject`.
 
 ----
 
@@ -120,10 +135,13 @@ FontsObject.getFontsByPostScriptName()
 
 **Description**
 
-This function will return an array of :ref:`fontobject` based on the Postscript name of a Font. If no suitable Font is found, it will return an empty Array.
+This function will return an array of :ref:`fontobject` based on the PostScript name of previously found Fonts. 
 
-.. note::
-   The returned array length can be more than 1 if you have multiple copies of a same font.
+It is perfectly valid to have multiple :ref:`fontobject` which share the same PostScript name, the order of these is determined by the order in which they were enumerated in the font environment. It is the entry at ``[0]`` which is used when setting the :ref::`TextDocument` ``font`` property.
+
+In addition, there is a special property of this API with regards to Variable fonts. If no :ref:`fontobject` matching the requested PostScript exists, but we find that there exist a Variable font which matches the requested PostScript name prefix, then this Variable font instance will be requested to create a matching :ref:`fontobject`. This is the only way that we will return an instance which did not exist prior to invoking this method.
+
+If no matching Font is found, it will return an empty Array.
 
 .. code:: javascript
 
@@ -133,9 +151,9 @@ This function will return an array of :ref:`fontobject` based on the Postscript 
 **Parameters**
 
 ====================  ========================================================
-postscriptName          A string containing the Postscript Name of the font.
+postscriptName          A string containing the PostScript Name of the font.
 ====================  ========================================================
 
 **Returns**
 
-An array of fontObjects.
+An array of :ref:`fontobject`.

--- a/docs/other/fontsobject.rst
+++ b/docs/other/fontsobject.rst
@@ -41,7 +41,7 @@ The Family Name in one font group is not guaranteed to have unique name compared
 
 In addition, it is perfectly acceptable to have multiple fonts with the same PostScript name, though only one will have the same (PostScript name, Technology, Primary Writing Script) tuple. In the case of true duplicates, it is undefined which will be returned and which will be suppressed.
 
-The family groups and :ref:`fontobject` in the group are sorted accordingly to the setting in the ``Character Panel`` dropdown ``Show Font Names in English``. If set to true, the ``Font.familyName`` and ``Font.styleName`` property is used, otherwise the ``Font.nativeFamilyName`` and ``Font.nativeStyleName`` property is used.
+The family groups and :ref:`Font objects <fontobject>` in the group are sorted accordingly to the setting in the Character Panel dropdown "Show Font Names in English". If set to true, the :ref:`familyName<FontObject.familyName>` and :ref:`styleName<FontObject.styleName>` property is used, otherwise the :ref:`nativeFamilyName<FontObject.nativeFamilyName>` and :ref:`nativeStyleName<FontObject.nativeStyleName>` property is used.
 
 :ref:`fontobject` for which ``Font.isSubstitute`` returns true are always sorted to the end as individual family groups.
 

--- a/docs/other/fontsobject.rst
+++ b/docs/other/fontsobject.rst
@@ -37,7 +37,7 @@ They are grouped into what is named a family group which are Arrays of :ref:`fon
 
 The Family Name of the group is simply the ``Font.familyName`` of any of the :ref:`fontobject` in the group.
 
-The Family Name in one font group is not guaranteed to have unique name compared to different font groups - the grouping is determined by a number of factors including the returned value of ``Font.technology`` and ``Font.writingScripts``.
+The Family Name in one font group is not guaranteed to have unique name compared to different font groups - the grouping is determined by a number of factors including the returned value of :ref:`FontObject.technology` and :ref:`FontObject.writingScripts`.
 
 In addition, it is perfectly acceptable to have multiple fonts with the same PostScript name, though only one will have the same (PostScript name, Technology, Primary Writing Script) tuple. In the case of true duplicates, it is undefined which will be returned and which will be suppressed.
 

--- a/docs/other/fontsobject.rst
+++ b/docs/other/fontsobject.rst
@@ -35,7 +35,7 @@ They are grouped into what is named a family group which are Arrays of :ref:`fon
 
 .. Naming and ordering::
 
-The Family Name of the group is simply the ``Font.familyName`` of any of the :ref:`fontobject` in the group.
+The Family Name of the group is simply the :ref:`familyName <FontObject.familyName>` of any of the :ref:`Font objects<fontobject>` in the group.
 
 The Family Name in one font group is not guaranteed to have unique name compared to different font groups - the grouping is determined by a number of factors including the returned value of :ref:`FontObject.technology` and :ref:`FontObject.writingScripts`.
 

--- a/docs/other/fontsobject.rst
+++ b/docs/other/fontsobject.rst
@@ -156,4 +156,4 @@ postscriptName          A string containing the PostScript Name of the font.
 
 **Returns**
 
-An array of :ref:`fontobject`.
+Array of :ref:`Font objects<fontobject>`; read-only.

--- a/docs/other/fontsobject.rst
+++ b/docs/other/fontsobject.rst
@@ -48,7 +48,7 @@ The family groups and :ref:`Font objects <fontobject>` in the group are sorted a
 
 **Type**
 
-Array of Arrays of :ref:`fontobject`; read-only.
+Array of Arrays of :ref:`Font objects <fontobject>`; read-only.
 
 **Example**
 

--- a/docs/other/fontsobject.rst
+++ b/docs/other/fontsobject.rst
@@ -86,7 +86,7 @@ The list of all the missing or substituted fonts of the current Project.
 
 **Type**
 
-Array of :ref:`fontobject`; read-only.
+Array of :ref:`Font objects<fontobject>`; read-only.
 
 ----
 

--- a/docs/other/fontsobject.rst
+++ b/docs/other/fontsobject.rst
@@ -122,7 +122,7 @@ StyleName               A string containing the Style Name of the font.
 
 **Returns**
 
-An array of :ref:`fontobject`.
+Array of :ref:`Font objects<fontobject>`; read-only.
 
 ----
 

--- a/docs/other/textdocument.rst
+++ b/docs/other/textdocument.rst
@@ -330,6 +330,32 @@ Array of two integers (minimum value of 1); read/write.
 
 ----
 
+.. _TextDocument.composerEngine:
+
+TextDocument.composerEngine
+*********************************************
+
+``textDocument.composerEngine``
+
+.. note::
+   | This functionality was added in After Effects 24.0.
+   | This functionality is currently in Beta and is subject to change.
+
+**Description**
+
+The text layer's paragraph composer engine option. By default new text layers will use the ``ComposerEngine.UNIVERSAL_TYPE_ENGINE``, the other enum value will only be encountered in projects created before the introduction of the new engine.
+
+If this attribute has a mixed value on a TextDocument, it will be read as ``undefined``.
+
+**Type**
+
+A ``ComposerEngine`` enumerated value; read-only. One of:
+
+-  ``ComposerEngine.LATIN_CJK_ENGINE``
+-  ``ComposerEngine.UNIVERSAL_TYPE_ENGINE``
+
+----
+
 .. _TextDocument.digitSet:
 
 TextDocument.digitSet


### PR DESCRIPTION
Added more commentary with Fonts.allFonts and Fonts.getFontsByPostScriptName.

Added more detail on the Font native vs non-native APIs.

Added TextDocument.composerEngine

ChangeLog handled by: https://github.com/aenhancers/after-effects-scripting-guide/pull/27