### PR TITLE
Add new script APIs for 26.0 Beta

### DIFF
--- a/docs/introduction/changelog.md
+++ b/docs/introduction/changelog.md
@@ -8,6 +8,17 @@ What's new and changed for scripting?
 
 ---
 
+## After Effects 26 (Beta)
+
+### After Effects 26.0 (Beta) (November 2025)
+
+- Scripting methods and attributes added:
+    - Added: [PropertyGroup.addVariableFontAxis()](../property/propertygroup.md#propertygroupaddvariablefontaxis)
+    - Added: [Property.propertyParameters](../property/property.md#propertypropertyparameters)
+    - Added: [Property.valueText](../property/property.md#propertyvaluetext)
+
+---
+
 ## After Effects 25
 
 ### [After Effects 25.4](https://helpx.adobe.com/after-effects/using/whats-new/2025-4.html) (August 2025)

--- a/docs/matchnames/layer/textlayer.md
+++ b/docs/matchnames/layer/textlayer.md
@@ -23,6 +23,7 @@
 | `ADBE Text First Margin`          | First Margin          |
 | `ADBE Text Last Margin`           | Last Margin           |
 | `ADBE Text More Options`          | More Options          |
+| `ADBE Text Variable Font Spacing` | Variable Font Spacing |
 | `ADBE Text Anchor Point Align`    | Grouping Alignment    |
 | `ADBE Text Animators`             | Animators             |
 

--- a/docs/property/property.md
+++ b/docs/property/property.md
@@ -460,6 +460,38 @@ Integer; read-only.
 
 ---
 
+### Property.propertyParameters
+
+`app.project.item(index).layer(index).propertySpec.propertyParameters`
+
+!!! note
+    This functionality was added in After Effects (Beta) 26.0 and is subject to change while it remains in Beta.
+
+#### Description
+
+An array of all item strings in a dropdown menu property. This attribute applies to dropdown menu properties of effects and layers, including custom strings in the Menu property of the Dropdown Menu Control.
+
+This property corresponds to [Property.setPropertyParameters()](#propertysetpropertyparameters), acting as the getter for the strings in a dropdown menu.
+
+#### Examples
+
+```javascript
+// Get all options from a Dropdown Menu Control
+var comp = app.project.activeItem;
+if (comp && comp.selectedLayers.length > 0) {
+    var lyr = comp.selectedLayers[0];
+    var fx = lyr.property("ADBE Effect Parade").property("Dropdown Menu Control");
+    var menuProp = fx.property("Menu");
+    var options = menuProp.propertyParameters; // Array of strings
+}
+```
+
+#### Type
+
+Array of strings; read-only.
+
+---
+
 ### Property.propertyValueType
 
 `app.project.item(index).layer(index).propertySpec.propertyValueType`
@@ -573,6 +605,36 @@ The type of value returned depends on the property value type. See [examples for
 #### Type
 
 A value appropriate for the type of the property (see [Property.propertyValueType](#propertypropertyvaluetype)); read-only.
+
+---
+
+### Property.valueText
+
+`app.project.item(index).layer(index).propertySpec.valueText`
+
+!!! note
+    This functionality was added in After Effects (Beta) 26.0 and is subject to change while it remains in Beta.
+
+#### Description
+
+The text string of the currently-selected item in a dropdown menu property. This attribute applies to dropdown menu properties of effects and layers, including custom strings in the Menu property of Dropdown Menu Controls.
+
+#### Examples
+
+```javascript
+// Get the currently-selected text string from a Dropdown Menu Control
+var comp = app.project.activeItem;
+if (comp && comp.selectedLayers.length > 0) {
+    var lyr = comp.selectedLayers[0];
+    var fx = lyr.property("ADBE Effect Parade").property("Dropdown Menu Control");
+    var menuProp = fx.property("Menu");
+    var selectedText = menuProp.valueText; // e.g., "Sunday"
+}
+```
+
+#### Type
+
+String; read-only.
 
 ---
 

--- a/docs/property/propertygroup.md
+++ b/docs/property/propertygroup.md
@@ -129,6 +129,83 @@ Boolean.
 
 ---
 
+### PropertyGroup.addVariableFontAxis()
+
+`app.project.item(index).layer(index).propertyGroupSpec.addVariableFontAxis(axisTag)`
+
+!!! note
+    This functionality was added in After Effects (Beta) 26.0 and is subject to change while it remains in Beta.
+
+#### Description
+
+Creates and returns a Property object for a variable font axis, and adds it to this property group. This method can only be called on the "ADBE Text Animator Properties" property group within a text animator.
+
+Common axis tags include (but are not limited to):
+
+- `"wght"` - Weight (100-900 typical range)
+- `"wdth"` - Width (percentage of normal width)
+- `"slnt"` - Slant (angle in degrees)
+- `"ital"` - Italic (0-1 range)
+- `"opsz"` - Optical Size (point size)
+
+Fonts may also include custom axes with 4-character uppercase tags (e.g., `"INFM"` for Informality).
+
+#### Variable Font Spacing
+
+When animating Variable Font axes, individual characters can change width. The Variable Font Spacing property (found in the "More Options" section of a text animator) controls how After Effects handles character spacing compensation for these width changes.
+
+The Variable Font Spacing property can be accessed via its matchName `"ADBE Text Variable Font Spacing"` and is a dropdown control property. This property appears only when at least one variable font axis is active in the animator.
+
+
+!!! tip
+    Axes must exist on the font to have any impact. To discover what axes a font supports, use [FontObject.designAxesData](../text/fontobject.md#fontobjectdesignaxesdata).
+
+#### Parameters
+
+| Parameter |  Type  |                                              Description                                               
+| --------- | ------ | -----------------------------------------------------------------------------------------------------|
+| `axisTag` | String | The 4-character tag identifying the variable font axis (e.g., `"wght"`, `"wdth"`, `"slnt"`, `"ital"`).
+
+#### Returns
+
+[Property object](property.md) representing the variable font axis.
+
+#### Examples
+
+```javascript
+// Create a comp
+var comp = app.project.items.addComp("Create Axis Comp", 1920, 1080, 1, 30, 30);
+comp.openInViewer();
+
+// Create a text layer
+var textLayer = comp.layers.addText("Hello World!");
+
+// Set the font to variable font
+var textDocument = textLayer.property("Source Text").value;
+textDocument.font = 'ShantellSans'; // Must be a variable font
+textLayer.property("Source Text").setValue(textDocument);
+
+// Get the text property and animators group
+var textProp = textLayer.property("Text");
+var animators = textProp.property("Animators");
+
+// Add a new animator
+var animator = animators.addProperty("ADBE Text Animator");
+var animatorProps = animator.property("ADBE Text Animator Properties");
+
+// Add the Weight axis
+var axisProp = animatorProps.addVariableFontAxis("wght");
+
+// Set a static value
+axisProp.setValue(700);
+
+// Set keyframes
+axisProp.setValueAtTime(0, 300);  // Light at 0 seconds
+axisProp.setValueAtTime(2, 900);  // Heavy at 2 seconds
+```
+
+---
+
 ### PropertyGroup.property()
 
 `app.project.item(index).layer(index).propertyGroupSpec.property(index)`

--- a/docs/text/fontobject.md
+++ b/docs/text/fontobject.md
@@ -20,24 +20,46 @@ Most of these APIs simply return information which is contained in the Font data
 #### Description
 
 Returns an Array of Objects, containing the design axes data from the font.
-Each object is composed of the axis `name`, `tag`, `min` value and `max` value.
+Each object is composed of the axis `name`, `tag`, `min` value, `max` value, and `default` value.
 
 !!! tip
     Will return undefined for non-variable fonts.
 
 #### Example
 
-This example will select the first returned Font Family Array.
+This example demonstrates how to see the axes of a variable font on a selected Text layer:
 
 ```javascript
-// Getting the first available Variable Font on the system
-var firstVariableFont = fontsWithDefaultDesignAxes[0];
-var axesData = firstVariableFont.designAxesData;
+// Prerequisite: Create and select a Text layer that uses a variable font
+var textLayer = app.project.activeItem.selectedLayers[0];
 
-// Getting the first design axis for that Font
-var firstAxis = axesData[0];
+// Get the font object
+var textDocument = textLayer.property("Source Text").value;
+var fontObject = textDocument.fontObject;
 
-alert(firstAxis.name+"\n"+firstAxis.tag+"\n"+firstAxis.min+"\n"+firstAxis.max);
+// Check for axes and display any that are found
+if (fontObject && fontObject.designAxesData) {
+    var axes = fontObject.designAxesData;
+    var message = "Variable Font Axes (" + axes.length + " total):\n\n";
+    
+    for (var i = 0; i < axes.length; i++) {
+        var axis = axes[i];
+        message += "Axis " + (i + 1) + ":\n";
+        message += "  Tag: " + axis.tag + "\n";
+        message += "  Name: " + axis.name + "\n";
+        message += "  Min: " + axis.min + "\n";
+        message += "  Max: " + axis.max + "\n";
+        message += "  Default: " + axis.default + "\n";
+        
+        if (i < axes.length - 1) {
+            message += "\n";
+        }
+    }
+    
+    alert(message);
+} else {
+    alert("No variable font axes found");
+}
 ```
 
 #### Type


### PR DESCRIPTION
This PR adds documention for new scripting APIs released in the After Effects (Beta) in November 2025.

- PropertyGroup.addVariableFontAxis
- Property.propertyParameters
- Property.valueText

All new APIs are noted as Beta-only and subject to potential changes while still in Beta. These docs will be updated to reflect any changes. 