### PR TITLE
Add new script APIs for Parametric Mesh Layer

### DIFF
--- a/docs/introduction/changelog.md
+++ b/docs/introduction/changelog.md
@@ -15,8 +15,9 @@ What's new and changed for scripting?
 - Scripting methods and attributes added:
     - Added: [LayerCollection.addParametricMesh()](../layer/layercollection.md#layercollectionaddparametricmesh)
     - Added: [ParametricMeshLayer object](../layer/parametricmeshlayer.md)
-    - Added: [ParametricMeshLayer.MeshOptions](../layer/parametricmeshlayer.md#parametricmeshlayermeshoptions)
-    - Added: [ParametricMeshLayer.BevelOptions](../layer/parametricmeshlayer.md#parametricmeshlayerbeveloptions)
+    - Added: [ParametricMeshLayer.ParametricMeshType](../layer/parametricmeshlayer.md/#parametricmeshlayerparametricmeshtype)
+    - Added: [ParametricMeshLayer.ParametricMeshOptions](../layer/parametricmeshlayer.md/#parametricmeshlayerparametricmeshoptions)
+    - Added: [ParametricMeshLayer.ParametricBevelOptions](../layer/parametricmeshlayer.md#parametricmeshlayerparametricbeveloptions)
 
 ### [After Effects 26.0](https://helpx.adobe.com/after-effects/using/2026.html) (January 2026)
 

--- a/docs/introduction/changelog.md
+++ b/docs/introduction/changelog.md
@@ -10,7 +10,7 @@ What's new and changed for scripting?
 
 ## After Effects 26
 
-### [After Effects 26.3](https://helpx.adobe.com/after-effects/using/whats-new.html) (June 2026)
+### [After Effects 26.3 Beta Build 58](https://community.adobe.com/announcements-532/new-in-beta-parametric-mesh-scripting-apis-1559505) (April 2026)
 
 - Scripting methods and attributes added:
     - Added: [LayerCollection.addParametricMesh()](../layer/layercollection.md#layercollectionaddparametricmesh)

--- a/docs/introduction/changelog.md
+++ b/docs/introduction/changelog.md
@@ -10,7 +10,15 @@ What's new and changed for scripting?
 
 ## After Effects 26
 
-### [After Effects 26.0](https://helpx.adobe.com/after-effects/using/whats-new.html) (January 2026)
+### [After Effects 26.3](https://helpx.adobe.com/after-effects/using/whats-new.html) (June 2026)
+
+- Scripting methods and attributes added:
+    - Added: [LayerCollection.addParametricMesh()](../layer/layercollection.md#layercollectionaddparametricmesh)
+    - Added: [ParametricMeshLayer object](../layer/parametricmeshlayer.md)
+    - Added: [ParametricMeshLayer.MeshOptions](../layer/parametricmeshlayer.md#parametricmeshlayermeshoptions)
+    - Added: [ParametricMeshLayer.BevelOptions](../layer/parametricmeshlayer.md#parametricmeshlayerbeveloptions)
+
+### [After Effects 26.0](https://helpx.adobe.com/after-effects/using/2026.html) (January 2026)
 
 - Scripting methods and attributes added:
     - Added: [PropertyGroup.addVariableFontAxis()](../property/propertygroup.md#propertygroupaddvariablefontaxis)

--- a/docs/layer/layercollection.md
+++ b/docs/layer/layercollection.md
@@ -259,12 +259,12 @@ Creates a new point text layer with [TextDocument.lineOrientation](../text/textd
 
 ---
 
-LayerCollection.addParametricMesh()
+### LayerCollection.addParametricMesh()
 
 `app.project.item(index).layers.addParametricMesh(meshType)`
 
 !!! note
-    This functionality was added in After Effects 26.3
+    This functionality was added in After Effects (Beta) 26.3 and is subject to change while it remains in Beta.
 
 #### Description
 
@@ -274,7 +274,7 @@ Creates a new parametric 3D mesh layer.
 
 |  Parameter   |  Type    |                                                                 Description                                                                  |
 | ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `meshType`   | MeshType | [MeshType](parametricmeshlayer.md#parametricmeshlayermeshtype) of the new layer. |
+| `meshType`   | [MeshType](parametricmeshlayer.md#parametricmeshlayermeshtype) | The mesh type of the new layer. |
 
 #### Returns
 

--- a/docs/layer/layercollection.md
+++ b/docs/layer/layercollection.md
@@ -259,6 +259,29 @@ Creates a new point text layer with [TextDocument.lineOrientation](../text/textd
 
 ---
 
+LayerCollection.addParametricMesh()
+
+`app.project.item(index).layers.addParametricMesh(meshType)`
+
+!!! note
+    This functionality was added in After Effects 26.3
+
+#### Description
+
+Creates a new parametric 3D mesh layer.
+
+#### Parameters
+
+|  Parameter   |  Type    |                                                                 Description                                                                  |
+| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `meshType`   | MeshType | [MeshType](parametricmeshlayer.md#parametricmeshlayermeshtype) of the new layer. |
+
+#### Returns
+
+[ParametricMeshLayer object](parametricmeshlayer.md).
+
+---
+
 ### LayerCollection.byName()
 
 `app.project.item(index).layers.byName(name)`

--- a/docs/layer/layercollection.md
+++ b/docs/layer/layercollection.md
@@ -275,7 +275,7 @@ Creates a new parametric 3D mesh layer.
 |  Parameter   |  Type    |                                                                 Description                                                                  |
 | ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`       | String                                                      | The name of the new layer.                                  |
-| `meshType`   | [MeshType](parametricmeshlayer.md#parametricmeshlayermeshtype) | The mesh type of the new layer. |
+| `meshType`   | [MeshType](parametricmeshlayer.md#parametricmeshlayerparametricmeshtype) | The mesh type of the new layer. |
 
 #### Returns
 

--- a/docs/layer/layercollection.md
+++ b/docs/layer/layercollection.md
@@ -261,7 +261,7 @@ Creates a new point text layer with [TextDocument.lineOrientation](../text/textd
 
 ### LayerCollection.addParametricMesh()
 
-`app.project.item(index).layers.addParametricMesh(meshType)`
+`app.project.item(index).layers.addParametricMesh(name, meshType)`
 
 !!! note
     This functionality was added in After Effects (Beta) 26.3 and is subject to change while it remains in Beta.
@@ -274,6 +274,7 @@ Creates a new parametric 3D mesh layer.
 
 |  Parameter   |  Type    |                                                                 Description                                                                  |
 | ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`       | String                                                      | The name of the new layer.                                  |
 | `meshType`   | [MeshType](parametricmeshlayer.md#parametricmeshlayermeshtype) | The mesh type of the new layer. |
 
 #### Returns

--- a/docs/layer/parametricmeshlayer.md
+++ b/docs/layer/parametricmeshlayer.md
@@ -10,7 +10,22 @@
 The ParametricMeshLayer object represents a Parametric Mesh layer within a composition.
 
 !!! info
-	ParametricMeshLayer is a subclass of [AVLayer object](avlayer.md). All methods and attributes of AVLayer are available when working with ParametricMeshLayer.
+	ParametricMeshLayer is a subclass of [AVLayer object](avlayer.md). It inherits the following properties and property groups from [AVLayer object](avlayer.md):
+
+- Marker
+- Time Remap
+- Transform
+    - Anchor Point
+    - Position
+    - Scale
+    - Orientation
+    - X Rotation
+    - Y Rotation
+    - Rotation
+    - Opacity
+- Layer Styles
+- Audio
+    - AudioLevels
 
 #### Example
 

--- a/docs/layer/parametricmeshlayer.md
+++ b/docs/layer/parametricmeshlayer.md
@@ -3,7 +3,7 @@
 `app.project.item(index).layer(index)`
 
 !!! note
-    This functionality was added in After Effects 26.3
+    This functionality was added in After Effects (Beta) 26.3 and is subject to change while it remains in Beta.
 
 #### Description
 
@@ -30,6 +30,9 @@ if (layer instanceof ParametricMeshLayer)
 
 `app.project.item(index).layer(index).meshType`
 
+!!! note
+    This functionality was added in After Effects (Beta) 26.3 and is subject to change while it remains in Beta.
+
 #### Description
 
 For a parametric mesh layer, its mesh type. Trying to set this attribute for a non-parametric mesh layer produces an error.
@@ -47,9 +50,12 @@ A `MeshType` enumerated value; read/write. One of:
 
 ---
 
-### ParametricMeshLayer.MeshOptions
+### ParametricMeshLayer.meshOptions
 
-`comp.layer(index).meshOptions`
+`app.project.item(index).layer(index).meshOptions`
+
+!!! note
+    This functionality was added in After Effects (Beta) 26.3 and is subject to change while it remains in Beta.
 
 #### Description
 
@@ -60,75 +66,77 @@ Gets/sets details about the structure of the parametric mesh.
 `MeshOptions` based on the MeshType of the layer, as follows.
 
 #### For MeshType.CUBE
-- `MeshOptions.width`
-- `MeshOptions.height`
-- `MeshOptions.depth`
-- `MeshOptions.smoothingAngle`
+- `meshOptions.width`
+- `meshOptions.height`
+- `meshOptions.depth`
+- `meshOptions.smoothingAngle`
 
 #### For MeshType.SPHERE
-- `MeshOptions.radius`
-- `MeshOptions.sides`
-- `MeshOptions.sliceCaps`
-- `MeshOptions.sliceStart`
-- `MeshOptions.sliceEnd`
-- `MeshOptions.smoothingAngle`
+- `meshOptions.radius`
+- `meshOptions.sides`
+- `meshOptions.sliceCaps`
+- `meshOptions.sliceStart`
+- `meshOptions.sliceEnd`
+- `meshOptions.smoothingAngle`
 
 #### For MeshType.PLANE
-- `MeshOptions.width`
-- `MeshOptions.length`
-- `MeshOptions.cornerRadius`
-- `MeshOptions.cornerSides`
+- `meshOptions.width`
+- `meshOptions.length`
+- `meshOptions.cornerRadius`
+- `meshOptions.cornerSides`
 
 ####  For Meshtype.TORUS
-- `MeshOptions.ringRadius`
-- `MeshOptions.pipeRadius`
-- `MeshOptions.ringSides`
-- `MeshOptions.pipeSides`
-- `MeshOptions.caps`
-- `MeshOptions.sliceStart`
-- `MeshOptions.sliceEnd`
-- `MeshOptions.smoothingAngle`
+- `meshOptions.ringRadius`
+- `meshOptions.pipeRadius`
+- `meshOptions.ringSides`
+- `meshOptions.pipeSides`
+- `meshOptions.caps`
+- `meshOptions.sliceStart`
+- `meshOptions.sliceEnd`
+- `meshOptions.smoothingAngle`
 
 ####  For MeshType.CONE
-- `MeshOptions.topRadius`
-- `MeshOptions.bottomRadius`
-- `MeshOptions.height`
-- `MeshOptions.sides`
-- `MeshOptions.topCap`
-- `MeshOptions.bottomCap`
-- `MeshOptions.sliceCaps`
-- `MeshOptions.sliceStart`
-- `MeshOptions.sliceEnd`
-- `MeshOptions.smoothingAngle`
+- `meshOptions.topRadius`
+- `meshOptions.bottomRadius`
+- `meshOptions.height`
+- `meshOptions.sides`
+- `meshOptions.topCap`
+- `meshOptions.bottomCap`
+- `meshOptions.sliceCaps`
+- `meshOptions.sliceStart`
+- `meshOptions.sliceEnd`
+- `meshOptions.smoothingAngle`
 
 #### For MeshType.CYLINDER
-- `MeshOptions.radius`
-- `MeshOptions.height`
-- `MeshOptions.sides`
-- `MeshOptions.topCap`
-- `MeshOptions.bottomCap`
-- `MeshOptions.sliceCaps`
-- `MeshOptions.sliceStart`
-- `MeshOptions.sliceEnd`
-- `MeshOptions.smoothingAngle`
+- `meshOptions.radius`
+- `meshOptions.height`
+- `meshOptions.sides`
+- `meshOptions.topCap`
+- `meshOptions.bottomCap`
+- `meshOptions.sliceCaps`
+- `meshOptions.sliceStart`
+- `meshOptions.sliceEnd`
+- `meshOptions.smoothingAngle`
 
 ---
 
-#### ParametricMeshLayer.BevelOptions
+### ParametricMeshLayer.bevelOptions
 
-`comp.layer(index).bevelOptions`
+`app.project.item(index).layer(index).bevelOptions`
+
+!!! note
+    This functionality was added in After Effects (Beta) 26.3 and is subject to change while it remains in Beta.
 
 #### Description
 
 Gets/sets details about the beveling of the parametric mesh.
 
 !!! info
-	Only Parametric Mesh Layers with `MeshType.CUBE`, `MeshType.CONE`, and `MeshType.CYLINDER` have `BevelOptions`.
+	Only Parametric Mesh Layers with `MeshType.CUBE`, `MeshType.CONE`, and `MeshType.CYLINDER` have `bevelOptions`.
 
 #### Type
 
 `BevelOptions` based on the MeshType of the layer, as follows.
-
 
 #### For MeshType.CUBE
 - `bevelOptions.radius`

--- a/docs/layer/parametricmeshlayer.md
+++ b/docs/layer/parametricmeshlayer.md
@@ -26,9 +26,9 @@ if (layer instanceof ParametricMeshLayer)
 
 ## Attributes
 
-### ParametricMeshLayer.meshType
+### ParametricMeshLayer.parametricMeshType
 
-`app.project.item(index).layer(index).meshType`
+`app.project.item(index).layer(index).parametricMeshType`
 
 !!! note
     This functionality was added in After Effects (Beta) 26.3 and is subject to change while it remains in Beta.
@@ -39,20 +39,20 @@ For a parametric mesh layer, its mesh type. Trying to set this attribute for a n
 
 #### Type
 
-A `MeshType` enumerated value; read/write. One of:
+A `ParametricMeshType` enumerated value; read/write. One of:
 
-- `MeshType.SPHERE`
-- `MeshType.PLANE`
-- `MeshType.CYLINDER`
-- `MeshType.CONE`
-- `MeshType.TORUS`
-- `MeshType.CUBE`
+- `ParametricMeshType.SPHERE`
+- `ParametricMeshType.PLANE`
+- `ParametricMeshType.CYLINDER`
+- `ParametricMeshType.CONE`
+- `ParametricMeshType.TORUS`
+- `ParametricMeshType.CUBE`
 
 ---
 
-### ParametricMeshLayer.meshOptions
+### ParametricMeshLayer.parametricMeshOptions
 
-`app.project.item(index).layer(index).meshOptions`
+`app.project.item(index).layer(index).parametricMeshOptions`
 
 !!! note
     This functionality was added in After Effects (Beta) 26.3 and is subject to change while it remains in Beta.
@@ -63,66 +63,66 @@ Gets/sets details about the structure of the parametric mesh.
 
 #### Type
 
-`MeshOptions` based on the MeshType of the layer, as follows.
+`ParametricMeshOptions` based on the ParametricMeshType of the layer, as follows.
 
-#### For MeshType.CUBE
-- `meshOptions.width`
-- `meshOptions.height`
-- `meshOptions.depth`
-- `meshOptions.smoothingAngle`
+#### For ParametricMeshType.CUBE
+- `parametricMeshOptions.width`
+- `parametricMeshOptions.height`
+- `parametricMeshOptions.depth`
+- `parametricMeshOptions.smoothingAngle`
 
-#### For MeshType.SPHERE
-- `meshOptions.radius`
-- `meshOptions.sides`
-- `meshOptions.sliceCaps`
-- `meshOptions.sliceStart`
-- `meshOptions.sliceEnd`
-- `meshOptions.smoothingAngle`
+#### For ParametricMeshType.SPHERE
+- `parametricMeshOptions.radius`
+- `parametricMeshOptions.sides`
+- `parametricMeshOptions.sliceCaps`
+- `parametricMeshOptions.sliceStart`
+- `parametricMeshOptions.sliceEnd`
+- `parametricMeshOptions.smoothingAngle`
 
-#### For MeshType.PLANE
-- `meshOptions.width`
-- `meshOptions.length`
-- `meshOptions.cornerRadius`
-- `meshOptions.cornerSides`
+#### For ParametricMeshType.PLANE
+- `parametricMeshOptions.width`
+- `parametricMeshOptions.length`
+- `parametricMeshOptions.cornerRadius`
+- `parametricMeshOptions.cornerSides`
 
-####  For Meshtype.TORUS
-- `meshOptions.ringRadius`
-- `meshOptions.pipeRadius`
-- `meshOptions.ringSides`
-- `meshOptions.pipeSides`
-- `meshOptions.caps`
-- `meshOptions.sliceStart`
-- `meshOptions.sliceEnd`
-- `meshOptions.smoothingAngle`
+#### For ParametricMeshType.TORUS
+- `parametricMeshOptions.ringRadius`
+- `parametricMeshOptions.pipeRadius`
+- `parametricMeshOptions.ringSides`
+- `parametricMeshOptions.pipeSides`
+- `parametricMeshOptions.caps`
+- `parametricMeshOptions.sliceStart`
+- `parametricMeshOptions.sliceEnd`
+- `parametricMeshOptions.smoothingAngle`
 
-####  For MeshType.CONE
-- `meshOptions.topRadius`
-- `meshOptions.bottomRadius`
-- `meshOptions.height`
-- `meshOptions.sides`
-- `meshOptions.topCap`
-- `meshOptions.bottomCap`
-- `meshOptions.sliceCaps`
-- `meshOptions.sliceStart`
-- `meshOptions.sliceEnd`
-- `meshOptions.smoothingAngle`
+#### For ParametricMeshType.CONE
+- `parametricMeshOptions.topRadius`
+- `parametricMeshOptions.bottomRadius`
+- `parametricMeshOptions.height`
+- `parametricMeshOptions.sides`
+- `parametricMeshOptions.topCap`
+- `parametricMeshOptions.bottomCap`
+- `parametricMeshOptions.sliceCaps`
+- `parametricMeshOptions.sliceStart`
+- `parametricMeshOptions.sliceEnd`
+- `parametricMeshOptions.smoothingAngle`
 
-#### For MeshType.CYLINDER
-- `meshOptions.radius`
-- `meshOptions.height`
-- `meshOptions.sides`
-- `meshOptions.topCap`
-- `meshOptions.bottomCap`
-- `meshOptions.sliceCaps`
-- `meshOptions.sliceStart`
-- `meshOptions.sliceEnd`
-- `meshOptions.smoothingAngle`
+#### For ParametricMeshType.CYLINDER
+- `parametricMeshOptions.radius`
+- `parametricMeshOptions.height`
+- `parametricMeshOptions.sides`
+- `parametricMeshOptions.topCap`
+- `parametricMeshOptions.bottomCap`
+- `parametricMeshOptions.sliceCaps`
+- `parametricMeshOptions.sliceStart`
+- `parametricMeshOptions.sliceEnd`
+- `parametricMeshOptions.smoothingAngle`
 
 ---
 
-### ParametricMeshLayer.bevelOptions
+### ParametricMeshLayer.parametricBevelOptions
 
-`app.project.item(index).layer(index).bevelOptions`
+`app.project.item(index).layer(index).parametricBevelOptions`
 
 !!! note
     This functionality was added in After Effects (Beta) 26.3 and is subject to change while it remains in Beta.
@@ -132,25 +132,25 @@ Gets/sets details about the structure of the parametric mesh.
 Gets/sets details about the beveling of the parametric mesh.
 
 !!! info
-	Only Parametric Mesh Layers with `MeshType.CUBE`, `MeshType.CONE`, and `MeshType.CYLINDER` have `bevelOptions`.
+	Only Parametric Mesh Layers with `ParametricMeshType.CUBE`, `ParametricMeshType.CONE`, and `ParametricMeshType.CYLINDER` have `parametricBevelOptions`.
 
 #### Type
 
-`BevelOptions` based on the MeshType of the layer, as follows.
+`ParametricBevelOptions` based on the ParametricMeshType of the layer, as follows.
 
-#### For MeshType.CUBE
-- `bevelOptions.radius`
-- `bevelOptions.sides`
+#### For ParametricMeshType.CUBE
+- `parametricBevelOptions.radius`
+- `parametricBevelOptions.sides`
 
-#### For MeshType.CONE
-- `bevelOptions.topRadius`
-- `bevelOptions.topSides`
-- `bevelOptions.bottomRadius`
-- `bevelOptions.bottomSides`
+#### For ParametricMeshType.CONE
+- `parametricBevelOptions.topRadius`
+- `parametricBevelOptions.topSides`
+- `parametricBevelOptions.bottomRadius`
+- `parametricBevelOptions.bottomSides`
 
-#### For MeshType.CYLINDER
-- `bevelOptions.radius`
-- `bevelOptions.sides`
+#### For ParametricMeshType.CYLINDER
+- `parametricBevelOptions.radius`
+- `parametricBevelOptions.sides`
 
 ---
 

--- a/docs/layer/parametricmeshlayer.md
+++ b/docs/layer/parametricmeshlayer.md
@@ -1,0 +1,148 @@
+# ParametricMeshLayer object
+
+`app.project.item(index).layer(index)`
+
+!!! note
+    This functionality was added in After Effects 26.3
+
+#### Description
+
+The ParametricMeshLayer object represents a Parametric Mesh layer within a composition.
+
+!!! info
+	ParametricMeshLayer is a subclass of [AVLayer object](avlayer.md). All methods and attributes of AVLayer are available when working with ParametricMeshLayer.
+
+#### Example
+
+If the first item in the project is a CompItem, and the first layer of that CompItem is a ParametricMeshLayer, the following checks its type.
+
+```javascript
+var layer = app.project.item(1).layer(1);
+if (layer instanceof ParametricMeshLayer)
+{
+    // do something
+}
+```
+
+## Attributes
+
+### ParametricMeshLayer.meshType
+
+`app.project.item(index).layer(index).meshType`
+
+#### Description
+
+For a parametric mesh layer, its mesh type. Trying to set this attribute for a non-parametric mesh layer produces an error.
+
+#### Type
+
+A `MeshType` enumerated value; read/write. One of:
+
+- `MeshType.SPHERE`
+- `MeshType.PLANE`
+- `MeshType.CYLINDER`
+- `MeshType.CONE`
+- `MeshType.TORUS`
+- `MeshType.CUBE`
+
+---
+
+### ParametricMeshLayer.MeshOptions
+
+`comp.layer(index).meshOptions`
+
+#### Description
+
+Gets/sets details about the structure of the parametric mesh.
+
+#### Type
+
+`MeshOptions` based on the MeshType of the layer, as follows.
+
+#### For MeshType.CUBE
+- `MeshOptions.width`
+- `MeshOptions.height`
+- `MeshOptions.depth`
+- `MeshOptions.smoothingAngle`
+
+#### For MeshType.SPHERE
+- `MeshOptions.radius`
+- `MeshOptions.sides`
+- `MeshOptions.sliceCaps`
+- `MeshOptions.sliceStart`
+- `MeshOptions.sliceEnd`
+- `MeshOptions.smoothingAngle`
+
+#### For MeshType.PLANE
+- `MeshOptions.width`
+- `MeshOptions.length`
+- `MeshOptions.cornerRadius`
+- `MeshOptions.cornerSides`
+
+####  For Meshtype.TORUS
+- `MeshOptions.ringRadius`
+- `MeshOptions.pipeRadius`
+- `MeshOptions.ringSides`
+- `MeshOptions.pipeSides`
+- `MeshOptions.caps`
+- `MeshOptions.sliceStart`
+- `MeshOptions.sliceEnd`
+- `MeshOptions.smoothingAngle`
+
+####  For MeshType.CONE
+- `MeshOptions.topRadius`
+- `MeshOptions.bottomRadius`
+- `MeshOptions.height`
+- `MeshOptions.sides`
+- `MeshOptions.topCap`
+- `MeshOptions.bottomCap`
+- `MeshOptions.sliceCaps`
+- `MeshOptions.sliceStart`
+- `MeshOptions.sliceEnd`
+- `MeshOptions.smoothingAngle`
+
+#### For MeshType.CYLINDER
+- `MeshOptions.radius`
+- `MeshOptions.height`
+- `MeshOptions.sides`
+- `MeshOptions.topCap`
+- `MeshOptions.bottomCap`
+- `MeshOptions.sliceCaps`
+- `MeshOptions.sliceStart`
+- `MeshOptions.sliceEnd`
+- `MeshOptions.smoothingAngle`
+
+---
+
+#### ParametricMeshLayer.BevelOptions
+
+`comp.layer(index).bevelOptions`
+
+#### Description
+
+Gets/sets details about the beveling of the parametric mesh.
+
+!!! info
+	Only Parametric Mesh Layers with `MeshType.CUBE`, `MeshType.CONE`, and `MeshType.CYLINDER` have `BevelOptions`.
+
+#### Type
+
+`BevelOptions` based on the MeshType of the layer, as follows.
+
+
+#### For MeshType.CUBE
+- `bevelOptions.radius`
+- `bevelOptions.sides`
+
+#### For MeshType.CONE
+- `bevelOptions.topRadius`
+- `bevelOptions.topSides`
+- `bevelOptions.bottomRadius`
+- `bevelOptions.bottomSides`
+
+#### For MeshType.CYLINDER
+- `bevelOptions.radius`
+- `bevelOptions.sides`
+
+---
+

--- a/docs/renderqueue/renderqueue.md
+++ b/docs/renderqueue/renderqueue.md
@@ -117,7 +117,7 @@ Gets a specified item from the ite ms collection.
 
 #### Description
 
-Pauses the current rendering process, or continues a paused rendering process. This is the same as clicking Pause in the Render Queue panel during a render. You can call this method from an [RenderQueueItem.onstatus](renderqueueitem.md#renderqueueitemonstatus) or [app.onError](../general/application.md#apponerror) callback.
+Pauses the current rendering process, or continues a paused rendering process. This is the same as clicking Pause in the Render Queue panel during a render. You can call this method from an [RenderQueueItem.onStatusChanged](renderqueueitem.md#renderqueueitemonstatuschanged) or [app.onError](../general/application.md#apponerror) callback.
 
 #### Parameters
 
@@ -140,7 +140,7 @@ Nothing.
 Starts the rendering process. This is the same as clicking Render in the Render Queue panel. The method does not return until the render process is complete. To pause or stop the rendering process, call [RenderQueue.pauseRendering()](#renderqueuepauserendering) or [RenderQueue.stopRendering()](#renderqueuestoprendering) from an `onError` or `onstatus` callback.
 
 - To respond to errors during the rendering process, define a callback function in [app.onError](../general/application.md#apponerror).
-- To respond to changes in the status of a particular item while the render is progressing, define a callback function in [RenderQueueItem.onstatus](renderqueueitem.md#renderqueueitemonstatus) in the associated RenderQueueItem object.
+- To respond to changes in the status of a particular item while the render is progressing, define a callback function in [RenderQueueItem.onStatusChanged](renderqueueitem.md#renderqueueitemonstatuschanged) in the associated RenderQueueItem object.
 
 #### Parameters
 
@@ -178,7 +178,7 @@ Nothing.
 
 #### Description
 
-Stops the rendering process. This is the same as clicking Stop in the Render Queue panel during a render. You can call this method from an [RenderQueueItem.onstatus](renderqueueitem.md#renderqueueitemonstatus) or [app.onError](../general/application.md#apponerror) callback.
+Stops the rendering process. This is the same as clicking Stop in the Render Queue panel during a render. You can call this method from an [RenderQueueItem.onStatusChanged](renderqueueitem.md#renderqueueitemonstatuschanged) or [app.onError](../general/application.md#apponerror) callback.
 
 #### Parameters
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
         - ShapeLayer: layer/shapelayer.md
         - TextLayer: layer/textlayer.md
         - ThreeDModelLayer: layer/threedmodellayer.md
+        - ParametricMeshLayer: layer/parametricmeshlayer.md
     - Property:
         - Property object: property/property.md
         - PropertyBase: property/propertybase.md


### PR DESCRIPTION
This PR adds documention for new scripting APIs released in the After Effects (Beta) in April 2026.

LayerCollection.addParametricMesh()
ParametricMeshLayer object
ParametricMeshLayer.ParametricMeshType
ParametricMeshLayer.ParametricMeshOptions
ParametricMeshLayer.ParametricBevelOptions
    
All new APIs are noted as Beta-only and subject to potential changes while still in Beta. These docs will be updated to reflect any changes.